### PR TITLE
libcublas v12.9.1.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!/abs.yaml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,9 @@
+# build_parameters:
+#   - "--suppress-variables"
+#   #- "--skip-existing"
+#   - "--error-overlinking"
+
+# staging_channel_upload_target: ctk-12.9-build-4
+
+# channels:
+# - https://staging.continuum.io/pbp/ctk-12.9-build-4

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,10 +1,9 @@
 arm_variant_type: # [aarch64]
   - sbsa          # [linux and aarch64]
-  - tegra         # [linux and aarch64]
+#  - tegra         # [linux and aarch64]
 c_stdlib_version:  # [linux]
-  - 2.28           # [linux and aarch64]
-  - 2.34           # [linux and aarch64]
-  - 2.28           # [linux and x86_64]
+  - "2.28"           # [linux and aarch64]
+#  - 2.34           # [linux and aarch64]
 
 zip_keys:               # [linux and aarch64]
   -                     # [linux and aarch64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,12 +2,10 @@
 {% set version = "12.9.1.4" %}
 {% set cuda_version = "12.9" %}
 {% set platform = "linux-x86_64" %}  # [linux64]
-{% set platform = "linux-ppc64le" %}  # [ppc64le]
 {% set platform = "linux-sbsa" %}  # [aarch64 and arm_variant_type=="sbsa"]
 {% set platform = "linux-aarch64" %}  # [aarch64 and arm_variant_type=="tegra"]
 {% set platform = "windows-x86_64" %}  # [win]
 {% set target_name = "x86_64-linux" %}  # [linux64]
-{% set target_name = "ppc64le-linux" %}  # [ppc64le]
 {% set target_name = "sbsa-linux" %}  # [aarch64 and arm_variant_type=="sbsa"]
 {% set target_name = "aarch64-linux" %}  # [aarch64 and arm_variant_type=="tegra"]
 {% set target_name = "x64" %}  # [win]
@@ -26,8 +24,8 @@ source:
   sha256: d534d98b0b453a98914dbf3adf47d7e84b55037abf02f87466439e1dcef581ed  # [win]
 
 build:
-  number: 1
-  skip: true  # [osx or ppc64le]
+  number: 0
+  skip: true  # [osx]
   script_env:
     - component_name={{ name }}
 
@@ -42,6 +40,14 @@ outputs:
   - name: libcublas
     build:
       binary_relocation: false
+      missing_dso_whitelist:
+        # Needed for the use of conda-build's --error-overlinking command-line argument
+        - '*libgcc_s.so*'           # [linux]
+        - '*libstdc++.so*'          # [linux]
+      overlinking_ignore_patterns:
+        # Workaround for LIEF's 'not a valid TAG' error
+        - '*libcublas*.so*'         # [linux and aarch64]
+        - '*libnvblas*.so*'         # [linux and aarch64]
     files:
       - lib/lib*blas*.so.*                            # [linux]
       - targets/{{ target_name }}/lib/lib*blas*.so.*  # [linux]
@@ -91,6 +97,9 @@ outputs:
       binary_relocation: false
       run_exports:
         - {{ pin_subpackage("libcublas", max_pin="x") }}
+      # Ignore 'runpaths ['$ORIGIN'] found' errors
+      runpath_whitelist:            # [linux]
+        - '$ORIGIN'                 # [linux]
     files:
       - lib/lib*blas*.so                            # [linux]
       - lib/pkgconfig                               # [linux]


### PR DESCRIPTION
libcublas 12.9.1.4

**Destination channel:** defaults

### Links

- [PKG-12799](https://anaconda.atlassian.net/browse/PKG-12799) 
- [CUDA 12.9 release notes](https://docs.nvidia.com/cuda/archive/12.9.1/cuda-toolkit-release-notes/index.html) for list of packages, version numbers, etc.
- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/cuda-nvcc-impl-feedstock/pull/10

### Explanation of changes:

- CUDA 12.9 release
- Based on upstream feedstock's `12.x` branch.
- Added `abs.yaml` for possible use of staging channels in future builds
- Removed Tegra builds from `cbc.yaml`. We may enable them in the future.
- Kept static library packages as they are dependencies for `cuda-libraries-static` package.

### Notes

- Staging channels for `cuda-nvcc-impl` will be removed before the merge


[PKG-12799]: https://anaconda.atlassian.net/browse/PKG-12799?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ